### PR TITLE
Fix panic when destinations are in same VPC

### DIFF
--- a/internal/app/cir/analyser/analyser.go
+++ b/internal/app/cir/analyser/analyser.go
@@ -73,6 +73,15 @@ func RunAnalysis(data scanner.AwsData, client *ec2.Client, port int32) ([]Analys
 			if !analysis.AreInTheSameVpc {
 				analysis.ConnectionBetweenVPCsIsValid = checkIfVPCConnectionValid(routeSource, routeDestination)
 				analysis.ConnectionBetweenVPCsIsActive = checkIfVPCConnectionIsActive(routeSource, client)
+			} else {
+				analysis.ConnectionBetweenVPCsIsValid = &Check{
+					IsPassing: true,
+					Reason:    "same vpc",
+				}
+				analysis.ConnectionBetweenVPCsIsActive = &Check{
+					IsPassing: true,
+					Reason:    "same vpc",
+				}
 			}
 
 			*listOfAnalysis = append(*listOfAnalysis, *analysis)


### PR DESCRIPTION
I got panic when I run query for 2 machines in same VPC and all checks were passed:

```
[dsimek@ds5500 cir] (main) $ ./cir run --from 10.37.6.142 --to 10.37.6.142 --port 8301
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x867c23]

goroutine 1 [running]:
github.com/michal-franc/cir/internal/app/cir/analyser.(*Analysis).CanTheyConnect(...)
	/home/dsimek/Repo/cir/internal/app/cir/analyser/analyser.go:38
github.com/michal-franc/cir/internal/app/cir/printer.PrintAnalysis(0xc00032e090, 0x13, 0xc000592300, 0x13, 0x206d, 0xc0002e29d8, 0xc0002e2a08, 0xc0002e29f0, 0xc0002e2a20, 0x1, ...)
	/home/dsimek/Repo/cir/internal/app/cir/printer/printer.go:35 +0x43
github.com/michal-franc/cir/internal/app/cir/commands.glob..func1(0xd4c860, 0xc000140cc0, 0x0, 0x6)
	/home/dsimek/Repo/cir/internal/app/cir/commands/run.go:94 +0x53c
github.com/spf13/cobra.(*Command).execute(0xd4c860, 0xc000140c00, 0x6, 0x6, 0xd4c860, 0xc000140c00)
	/home/dsimek/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:856 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xd4c5e0, 0xc000000180, 0x200000003, 0xc000000180)
	/home/dsimek/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/home/dsimek/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
github.com/michal-franc/cir/internal/app/cir/commands.Execute()
	/home/dsimek/Repo/cir/internal/app/cir/commands/root.go:22 +0x31
main.main()
	/home/dsimek/Repo/cir/cmd/cir/main.go:8 +0x25

```


The PR fixes panic by creating `Check` object also when destinations are in same VPC.